### PR TITLE
added support for empty patterns

### DIFF
--- a/src/main/gen/com/github/xepozz/robots_txt/language/parser/RobotsTxtParser.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/parser/RobotsTxtParser.java
@@ -1,15 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.parser;
 
-import com.intellij.lang.ASTNode;
-import com.intellij.lang.LightPsiParser;
 import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiBuilder.Marker;
-import com.intellij.lang.PsiParser;
-import com.intellij.psi.tree.IElementType;
-
 import static com.github.xepozz.robots_txt.language.psi.RobotsTxtTypes.*;
 import static com.intellij.lang.parser.GeneratedParserUtilBase.*;
+import com.intellij.psi.tree.IElementType;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.tree.TokenSet;
+import com.intellij.lang.PsiParser;
+import com.intellij.lang.LightPsiParser;
 
 @SuppressWarnings({"SimplifiableIfStatement", "UnusedAssignment"})
 public class RobotsTxtParser implements PsiParser, LightPsiParser {
@@ -71,7 +71,7 @@ public class RobotsTxtParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // directive DELIMITER value
+  // directive DELIMITER value?
   public static boolean rule(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "rule")) return false;
     if (!nextTokenIs(b, TEXT)) return false;
@@ -80,9 +80,16 @@ public class RobotsTxtParser implements PsiParser, LightPsiParser {
     r = directive(b, l + 1);
     p = r; // pin = 1
     r = r && report_error_(b, consumeToken(b, DELIMITER));
-    r = p && value(b, l + 1) && r;
+    r = p && rule_2(b, l + 1) && r;
     exit_section_(b, l, m, r, p, null);
     return r || p;
+  }
+
+  // value?
+  private static boolean rule_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "rule_2")) return false;
+    value(b, l + 1);
+    return true;
   }
 
   /* ********************************************************** */

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtDirective.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtDirective.java
@@ -1,6 +1,8 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
 
 public interface RobotsTxtDirective extends PsiElement {

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtRule.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtRule.java
@@ -1,9 +1,9 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public interface RobotsTxtRule extends PsiElement {
 

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtTypes.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtTypes.java
@@ -1,12 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi;
 
-import com.github.xepozz.robots_txt.language.psi.impl.RobotsTxtDirectiveImpl;
-import com.github.xepozz.robots_txt.language.psi.impl.RobotsTxtRuleImpl;
-import com.github.xepozz.robots_txt.language.psi.impl.RobotsTxtValueImpl;
-import com.intellij.lang.ASTNode;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
+import com.intellij.psi.PsiElement;
+import com.intellij.lang.ASTNode;
+import com.github.xepozz.robots_txt.language.psi.impl.*;
 
 public interface RobotsTxtTypes {
 
@@ -27,7 +25,8 @@ public interface RobotsTxtTypes {
       }
       else if (type == RULE) {
         return new RobotsTxtRuleImpl(node);
-      } else if (type == VALUE) {
+      }
+      else if (type == VALUE) {
         return new RobotsTxtValueImpl(node);
       }
       throw new AssertionError("Unknown element type: " + type);

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtValue.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtValue.java
@@ -1,9 +1,11 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi;
 
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLiteralValue;
 import com.intellij.psi.PsiReference;
-import org.jetbrains.annotations.NotNull;
 
 public interface RobotsTxtValue extends PsiLiteralValue {
 

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtVisitor.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/RobotsTxtVisitor.java
@@ -1,10 +1,10 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi;
 
-import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiLiteralValue;
-import org.jetbrains.annotations.NotNull;
 
 public class RobotsTxtVisitor extends PsiElementVisitor {
 

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtDirectiveImpl.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtDirectiveImpl.java
@@ -1,12 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi.impl;
 
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtDirective;
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtVisitor;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.psi.util.PsiTreeUtil;
+import static com.github.xepozz.robots_txt.language.psi.RobotsTxtTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.github.xepozz.robots_txt.language.psi.*;
 
 public class RobotsTxtDirectiveImpl extends ASTWrapperPsiElement implements RobotsTxtDirective {
 
@@ -20,7 +23,7 @@ public class RobotsTxtDirectiveImpl extends ASTWrapperPsiElement implements Robo
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-      if (visitor instanceof RobotsTxtVisitor) accept((RobotsTxtVisitor) visitor);
+    if (visitor instanceof RobotsTxtVisitor) accept((RobotsTxtVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtRuleImpl.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtRuleImpl.java
@@ -1,15 +1,15 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi.impl;
 
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtDirective;
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtRule;
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtValue;
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtVisitor;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.intellij.psi.util.PsiTreeUtil;
+import static com.github.xepozz.robots_txt.language.psi.RobotsTxtTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.github.xepozz.robots_txt.language.psi.*;
 
 public class RobotsTxtRuleImpl extends ASTWrapperPsiElement implements RobotsTxtRule {
 

--- a/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtValueImpl.java
+++ b/src/main/gen/com/github/xepozz/robots_txt/language/psi/impl/RobotsTxtValueImpl.java
@@ -1,13 +1,16 @@
 // This is a generated file. Not intended for manual editing.
 package com.github.xepozz.robots_txt.language.psi.impl;
 
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtValue;
-import com.github.xepozz.robots_txt.language.psi.RobotsTxtVisitor;
-import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import java.util.List;
+import org.jetbrains.annotations.*;
 import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static com.github.xepozz.robots_txt.language.psi.RobotsTxtTypes.*;
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.github.xepozz.robots_txt.language.psi.*;
 import com.intellij.psi.PsiReference;
-import org.jetbrains.annotations.NotNull;
 
 public class RobotsTxtValueImpl extends ASTWrapperPsiElement implements RobotsTxtValue {
 
@@ -21,7 +24,7 @@ public class RobotsTxtValueImpl extends ASTWrapperPsiElement implements RobotsTx
 
   @Override
   public void accept(@NotNull PsiElementVisitor visitor) {
-      if (visitor instanceof RobotsTxtVisitor) accept((RobotsTxtVisitor) visitor);
+    if (visitor instanceof RobotsTxtVisitor) accept((RobotsTxtVisitor)visitor);
     else super.accept(visitor);
   }
 

--- a/src/main/kotlin/com/github/xepozz/robots_txt/language/parser/RobotsTxt.bnf
+++ b/src/main/kotlin/com/github/xepozz/robots_txt/language/parser/RobotsTxt.bnf
@@ -19,7 +19,7 @@ file ::= entry*
 
 private entry ::= rule | COMMENT | EOL
 
-rule ::= directive DELIMITER value
+rule ::= directive DELIMITER value?
 {
     pin=1
 }


### PR DESCRIPTION
From the perspective of RFC 9309, this `robots.txt` is valid:
```
User-agent: *
Disallow:
```

but the plugin will complain about this: `RobotsTxtTokenType.TEXT expected`.


```ebnf
rule = *WS ("allow" / "disallow") *WS ":"
      *WS (path-pattern / empty-pattern) EOL
path-pattern = "/" *UTF8-char-noctl ; valid URI path pattern
empty-pattern = *WS
```
